### PR TITLE
bug: fixed platform version. Changed it from iOS 13 to 14

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+    contents: read
+
+jobs:
+    dependency-review:
+        runs-on: ubuntu-latest
+        steps:
+        - name: 'Checkout Repository'
+            uses: actions/checkout@v2
+        - name: Dependency Review
+            uses: github/dependency-review-action@v1
+            with:
+                # Possible values: "critical", "high", "moderate", "low"
+                fail-on-severity: 'high'

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftUISnappingScrollView",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v14)
 //        .macCatalyst(.v14),
 //        .macOS(.v11),
 //        .tvOS(.v14),


### PR DESCRIPTION
The package will not compile under Xcode 14.3 because the platform version is set to iOS 13

 platforms: [
        .iOS(.v13)

@StateObject is only available on iOS 14.0+

I updated it to .iOS(.v14) to get it to compile
<img width="1125" alt="Screenshot 2023-03-31 at 2 40 34 PM" src="https://user-images.githubusercontent.com/103443014/229237933-17a5d19b-f22f-4d57-a967-a589ef63a11d.png">
